### PR TITLE
Use ':' as the default MAC address segment spearator instead of '.'

### DIFF
--- a/src/lib/mac/addr.rs
+++ b/src/lib/mac/addr.rs
@@ -35,7 +35,7 @@ impl MacAddr {
     }
 
     pub fn to_string(&self) -> String {
-        format!("{:>02X}:{:>02X}:{:>02X}:{:>02X}:{:>02X}:{:>02X}",
+        format!("{:>02X}-{:>02X}-{:>02X}-{:>02X}-{:>02X}-{:>02X}",
                 self.bytes[0],
                 self.bytes[1],
                 self.bytes[2],


### PR DESCRIPTION
- MacAddr::from_str accepts both ':' and '-' as separators for segments in MAC addresses.
- MacAddr::to_string uses ':' as a segment separator.
- MacAddr:from_str accepts addresses with 6 segments only.
- MacAddr:from_str fails on incorrect symbols in an address.
- Tests for MacAddr:from_str and MacAddr:to_string has been added.

The justification for the change: https://en.wikipedia.org/wiki/MAC_address#Notational_conventions . 

BTW, you already use the right notation in the e1000 driver to save the NIC address to /etc/net/mac, but since the driver starts before the fs process it can't actually save the address to FS so no errors arise when ethernetd parses the file. 

Speaking of which, I guess the /etc/net/mac entry in filesystem.toml has to be updated to "0:0:0:0:0:0", but I'm not sure if I'm supposed to open a separate PR for it.