### PR TITLE
whois: Fix bug made by redox-os/arg-parser#2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 [[package]]
 name = "arg_parser"
 version = "0.1.0"
-source = "git+https://github.com/redox-os/arg-parser.git#ed88287e60b2e1de2e67a2f8b32ffda242127277"
+source = "git+https://github.com/redox-os/arg-parser.git#1b6a9505a1e9c39af1836ecbee293a987619a539"
 
 [[package]]
 name = "base64"

--- a/src/whois/main.rs
+++ b/src/whois/main.rs
@@ -33,14 +33,12 @@ fn main() {
             exit(0);
         }
 
-        let hostname = parser.get_opt("host").unwrap();
-        if !hostname.is_empty() {
+        if let Some(hostname) = parser.get_opt("host") {
             // For easier case insenstive comparisons, lowercase the host.
             host = hostname.to_ascii_lowercase();
         }
 
-        let port_string = parser.get_opt("port").unwrap();
-        if !port_string.is_empty() {
+        if let Some(port_string) = parser.get_opt("port") {
             match port_string.parse::<u16>() {
                 Ok(num) => port = num,
                 Err(e) => {


### PR DESCRIPTION
There is a bug where the program panics if no option is provided, due to redox-os/arg-parser#2 . Before that it only returned an empty string. I thought this behaviour was intentional at first not a bug for arg-parser.