### PR TITLE
Fix deprecation warning on ping and dns binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,19 +1,3 @@
-[root]
-name = "netutils"
-version = "0.1.0"
-dependencies = [
- "arg_parser 0.1.0 (git+https://github.com/redox-os/arg-parser.git)",
- "extra 0.1.0 (git+https://github.com/redox-os/libextra.git)",
- "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper-rustls 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "ntpclient 0.0.1 (git+https://github.com/willem66745/ntpclient-rust)",
- "pbr 1.0.0 (git+https://github.com/a8m/pb)",
- "redox_event 0.1.0 (git+https://github.com/redox-os/event.git)",
- "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "arg_parser"
 version = "0.1.0"
@@ -171,6 +155,22 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "netutils"
+version = "0.1.0"
+dependencies = [
+ "arg_parser 0.1.0 (git+https://github.com/redox-os/arg-parser.git)",
+ "extra 0.1.0 (git+https://github.com/redox-os/libextra.git)",
+ "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-rustls 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ntpclient 0.0.1 (git+https://github.com/willem66745/ntpclient-rust)",
+ "pbr 1.0.0 (git+https://github.com/a8m/pb)",
+ "redox_event 0.1.0 (git+https://github.com/redox-os/event.git)",
+ "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/dns/main.rs
+++ b/src/dns/main.rs
@@ -1,12 +1,10 @@
-#![feature(lookup_host)]
-
 use std::{env, process};
 use std::io::{stderr, Write};
-use std::net::lookup_host;
+use std::net::ToSocketAddrs;
 
 fn main(){
     if let Some(name) = env::args().nth(1) {
-        for addr in lookup_host(&name).unwrap() {
+        for addr in (name.as_str(), 0).to_socket_addrs().unwrap() {
             println!("{}", addr.ip());
         }
     } else {


### PR DESCRIPTION
I noticed some deprecation warnings in netutils when updating my build today, and thought it was a good first rusty contribution to Redox.

Since rust-lang/rust#47510, lookup_host host is deprecated, and the way to resolve IP addresses is now using [std::net::ToSocketAddrs](https://doc.rust-lang.org/beta/std/net/trait.ToSocketAddrs.html).

Again, this is my first Rust contribution to Redox, so please let me know if something is wrong, you can also reach me on the chat.