### PR TITLE
Fix wget failing to parse urls that contained an '=' character

### DIFF
--- a/src/wget/main.rs
+++ b/src/wget/main.rs
@@ -70,7 +70,7 @@ fn main() {
         .add_opt("O", "output-document");
     parser.parse(env::args());
 
-    match parser.args.get(0) {
+    match env::args().nth(1) {
         Some(url) => match parser.get_opt("output-document") {
             Some(path) => match File::create(&path) {
                 Ok(mut file) => {


### PR DESCRIPTION
As pointed out in #29 `wget` doesn't accept urls that contain an `=` character, this is due to the way [redox-os/arg-parser](https://github.com/redox-os/arg-parser) parses arguments.